### PR TITLE
#Fix Main.py  Widget Contribute "Link"

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class MyWindow1(Gtk.Window):
 
     def on_contribute_clicked(self, widget):
         print("User chose: Contribute")
-        subprocess.run(["xdg-open", "https://github.com/LinuxGamer/Universe/blob/main/Docs/CONTRIBUTE.md"])
+        subprocess.run(["xdg-open", "https://github.com/LinuxGamer/Universe/blob/main/Docs/CONTRIBUTING.md"])
 
     def on_launcher_clicked(self, widget):
         print("User chose: App Launcher")


### PR DESCRIPTION
Fixes #
1. Contributing widget within the application linked to the wrong address of the website, and points to 404 Page instead.


## Proposed Changes
- Modified a link within Main.py for contribute widget, which has been using the wrong assigned linked of " Contribute.md " <-- Changed into " Controbuting.md " Panel works as intended.
